### PR TITLE
Do not use the workaround in Sketch 90

### DIFF
--- a/src/build-table.js
+++ b/src/build-table.js
@@ -72,7 +72,9 @@ function createTable() {
         newLayer.frame.y += newLayer.frame.height * row;
 
         // set the title value
-        newLayer.sketchObject.ensureDetachHasUpdated(); // This is a workaround for a bug in Sketch 91
+        if (sketch.version.sketch > 90) {
+          newLayer.sketchObject.ensureDetachHasUpdated(); // This is a workaround for a bug in Sketch 91
+        }
         newLayer.setOverrideValue(newLayer.overrides[0], label);
 
         // set the newLayer name which sets the export file name


### PR DESCRIPTION
As mentioned in #4, the workaround I added in #5 stops the plugin from working on Sketch 90.

This PR fixes that.